### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -19,3 +19,7 @@ reason = "Awaiting release of fix from transient dependency"
 [[IgnoredVulns]]
 id = "GHSA-72hv-8253-57qq"
 reason = "Awaiting release of fix from transient dependency"
+
+[[IgnoredVulns]]
+id = "GHSA-3pxv-7cmr-fjr4"
+reason = "Awaiting release of fix from transient dependency"


### PR DESCRIPTION
Automated fix to suppress the `GHSA-3pxv-7cmr-fjr4` vulnerability reported by OSV Scanner after a dependency update.

---
*PR created automatically by Jules for task [8065384895428738203](https://jules.google.com/task/8065384895428738203) started by @boxheed*