### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'pl.allegro.tech.build:axion-release-plugin:1.21.1'
-        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
+        classpath 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
         classpath 'com.fizzpod:gradle-gitignore-plugin:5.0.4'
         classpath 'com.fizzpod:gradle-layout-plugin:6.1.1'
         classpath 'com.fizzpod:gradle-sweeney-plugin:7.0.6'
@@ -40,7 +40,7 @@ compileGroovy {
 dependencies {
     runtimeOnly 'pl.allegro.tech.build:axion-release-plugin:1.21.1'
     runtimeOnly 'com.fizzpod:gradle-gitignore-plugin:5.0.4'
-    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.8'
+    runtimeOnly 'com.fizzpod:gradle-extended-info-plugin:15.0.7'
     runtimeOnly 'com.fizzpod:gradle-pater-build-plugin:4.0.5'
     runtimeOnly 'com.fizzpod:gradle-layout-plugin:6.1.1'
     runtimeOnly 'com.fizzpod:gradle-sweeney-plugin:7.0.6'

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,23 +1,5 @@
 [[IgnoredVulns]]
-id = "GHSA-pq2g-wx69-c263"
-ignoreUntil = 2025-04-01 # Optional exception expiry date
-reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
-id = "GHSA-p53j-g8pw-4w5f"
-ignoreUntil = 2025-10-01
-reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
-id = "GHSA-j288-q9x7-2f5v"
-reason = "Not critically affected"
-
-[[IgnoredVulns]]
 id = "GHSA-vc5p-v9hr-52mj"
-reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
-id = "GHSA-72hv-8253-57qq"
 reason = "Awaiting release of fix from transient dependency"
 
 [[IgnoredVulns]]


### PR DESCRIPTION
Fixes the build failure caused by Dependabot incorrectly bumping `com.fizzpod:gradle-extended-info-plugin` to 15.0.8, which does not exist. Reverted this plugin version to `15.0.7` while leaving `osv-scanner-plugin` at `5.0.8`. Also removed unused vulnerability ignores reported by `osv-scanner` to unblock the CI build.

---
*PR created automatically by Jules for task [8843815648695954016](https://jules.google.com/task/8843815648695954016) started by @boxheed*