### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,13 @@ dependencies {
             version {
                 require '1.78.1'
             }
-     
+        }
+
+        implementation('org.bouncycastle:bcprov-jdk18on') {
+            because 'version 1.82 imported as a dependency has a vulnerability'
+            version {
+                require '1.84'
+            }
         }
 
         implementation('org.eclipse.jgit:org.eclipse.jgit') {

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -21,7 +21,3 @@ reason = "Awaiting release of fix from transient dependency"
 [[IgnoredVulns]]
 id = "GHSA-wg6q-6289-32hp"
 reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
-id = "GHSA-c3fc-8qff-9hwx"
-reason = "Awaiting release of fix from transient dependency"


### PR DESCRIPTION
Fixes failing dependency vulnerability scans due to an updated plugin transient dependency and outdated ignores. Added constraints to force an updated bouncycastle build, and cleared out two old unused ignores to placate the OSV Scanner.

---
*PR created automatically by Jules for task [13711225495728413774](https://jules.google.com/task/13711225495728413774) started by @boxheed*