### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,20 +1,4 @@
 [[IgnoredVulns]]
-id = "GHSA-vc5p-v9hr-52mj"
-reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
-id = "GHSA-3pxv-7cmr-fjr4"
-reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
-id = "GHSA-445c-vh5m-36rj"
-reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
-id = "GHSA-6hg6-v5c8-fphq"
-reason = "Awaiting release of fix from transient dependency"
-
-[[IgnoredVulns]]
 id = "GHSA-cj8j-37rh-8475"
 reason = "Awaiting release of fix from transient dependency"
 


### PR DESCRIPTION
Removes unused vulnerability ignores from `osv-scanner.toml`. The updating of the OSV scanner plugin cleared up previously failing vulnerabilities resulting in warnings/errors about unused ignores.

---
*PR created automatically by Jules for task [3763860610458953164](https://jules.google.com/task/3763860610458953164) started by @boxheed*